### PR TITLE
CS224W - Bag of Tricks for Node Classification with GNN - Label Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## \[2.7.0\] - 2024-MM-DD
 
 ### Added
-
+- Added the `label_usage` model ([#9845](https://github.com/pyg-team/pytorch_geometric/pull/9845))
 - Added the `use_pcst` option to `WebQSPDataset` ([#9722](https://github.com/pyg-team/pytorch_geometric/pull/9722))
 - Allowed users to pass `edge_weight` to `GraphUNet` models ([#9737](https://github.com/pyg-team/pytorch_geometric/pull/9737))
 - Consolidated `examples/ogbn_{papers_100m,products_gat,products_sage}.py` into `examples/ogbn_train.py` ([#9467](https://github.com/pyg-team/pytorch_geometric/pull/9467))

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -1,26 +1,27 @@
 import torch
 
-from torch_geometric.nn.models import LabelUsage
-from torch_geometric.nn.models import GCN
+from torch_geometric.nn.models import GCN, LabelUsage
 
 
 def test_label_usage():
-    x = torch.rand(6, 4) # 6 nodes, 4 features
+    x = torch.rand(6, 4)  # 6 nodes, 4 features
     y = torch.tensor([1, 0, 0, 2, 1, 1])
     edge_index = torch.tensor([[0, 1, 1, 2, 4, 5], [1, 0, 2, 1, 5, 4]])
     train_idx = torch.tensor([0, 2, 3, 5])
 
     num_classes = len(torch.unique(y))
-    base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8, num_layers=3, out_channels=num_classes)
+    base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8,
+                     num_layers=3, out_channels=num_classes)
     label_usage = LabelUsage(
         base_model=base_model,
         num_classes=num_classes,
-        split_ratio=0.6, 
-        num_recycling_iterations=10, 
-        return_tuple=True, 
+        split_ratio=0.6,
+        num_recycling_iterations=10,
+        return_tuple=True,
     )
-    
-    output, train_labels_idx, train_pred_idx = label_usage(x, edge_index, y, train_idx)
+
+    output, train_labels_idx, train_pred_idx = label_usage(
+        x, edge_index, y, train_idx)
 
     # Check output shapes
     assert output.size(0) == x.size(0)
@@ -28,13 +29,14 @@ def test_label_usage():
 
     # Check split ratio masking
     actual_ratio = len(train_labels_idx) / len(train_idx)
-    assert torch.isclose(torch.tensor(actual_ratio), torch.tensor(label_usage.split_ratio), atol=0.1)
+    assert torch.isclose(torch.tensor(actual_ratio),
+                         torch.tensor(label_usage.split_ratio), atol=0.1)
 
     # Test zero recycling iterations
     label_usage = LabelUsage(
         base_model=base_model,
         num_classes=num_classes,
-        num_recycling_iterations=0, 
+        num_recycling_iterations=0,
     )
     output = label_usage(x, edge_index, y, train_idx)
     assert output.size(0) == x.size(0)

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -29,9 +29,10 @@ def test_label_usage():
     mask_bool = torch.zeros(num_nodes, dtype=torch.bool)
     mask_bool[mask] = True
 
-    label_usage_bool = LabelUsage(base_model=base_model, num_classes=num_classes,
-                             split_ratio=0.6, num_recycling_iterations=10,
-                             return_tuple=True)
+    label_usage_bool = LabelUsage(base_model=base_model,
+                                  num_classes=num_classes, split_ratio=0.6,
+                                  num_recycling_iterations=10,
+                                  return_tuple=True)
 
     output, train_labels_idx, train_pred_idx = label_usage(
         feat=x, edge_index=edge_index, y=y, mask=mask_bool)

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -13,10 +13,11 @@ def test_label_usage():
     num_classes = len(torch.unique(y))
     base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8, num_layers=3, out_channels=num_classes)
     label_usage = LabelUsage(
-        split_ratio=0.5, 
+        base_model=base_model,
+        num_classes=num_classes,
+        split_ratio=0.6, 
         num_recycling_iterations=10, 
         return_tuple=True, 
-        base_model=base_model,
     )
     
     output, train_labels_idx, train_pred_idx = label_usage(x, edge_index, y, train_idx)
@@ -31,10 +32,9 @@ def test_label_usage():
 
     # Test zero recycling iterations
     label_usage = LabelUsage(
-        split_ratio=0.5, 
-        num_recycling_iterations=0, 
-        return_tuple=False, 
         base_model=base_model,
+        num_classes=num_classes,
+        num_recycling_iterations=0, 
     )
     output = label_usage(x, edge_index, y, train_idx)
     assert output.size(0) == x.size(0)

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -33,7 +33,7 @@ def test_label_usage():
                              split_ratio=0.6, num_recycling_iterations=10,
                              return_tuple=True)
 
-    output, train_labels_idx, train_pred_idx = label_usage(
+    output, train_labels_idx, train_pred_idx = label_usage_bool(
         feat=x, edge_index=edge_index, y=y, mask=mask_bool)
 
     # Check output shapes

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -4,12 +4,11 @@ from torch_geometric.nn.models import GCN, LabelUsage
 
 
 def test_label_usage():
+    # Test mask index tensor
     x = torch.rand(6, 4)  # 6 nodes, 4 features
     y = torch.tensor([1, 0, 0, 2, 1, 1])
     edge_index = torch.tensor([[0, 1, 1, 2, 4, 5], [1, 0, 2, 1, 5, 4]])
-    train_idx = torch.tensor([0, 2, 3, 5])
-    val_idx = torch.tensor([1])
-    test_idx = torch.tensor([4])
+    mask = torch.tensor([0, 2, 3, 5])
 
     num_classes = len(torch.unique(y))
     base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8,
@@ -19,8 +18,23 @@ def test_label_usage():
                              return_tuple=True)
 
     output, train_labels_idx, train_pred_idx = label_usage(
-        feat=x, edge_index=edge_index, y=y, mask=train_idx, val_idx=val_idx,
-        test_idx=test_idx)
+        feat=x, edge_index=edge_index, y=y, mask=mask)
+
+    # Check output shapes
+    assert output.size(0) == x.size(0)
+    assert output.size(1) == num_classes
+
+    # Test mask bool tensor
+    num_nodes = x.size(0)
+    mask_bool = torch.zeros(num_nodes, dtype=torch.bool)
+    mask_bool[mask] = True
+
+    label_usage_bool = LabelUsage(base_model=base_model, num_classes=num_classes,
+                             split_ratio=0.6, num_recycling_iterations=10,
+                             return_tuple=True)
+
+    output, train_labels_idx, train_pred_idx = label_usage(
+        feat=x, edge_index=edge_index, y=y, mask=mask_bool)
 
     # Check output shapes
     assert output.size(0) == x.size(0)
@@ -30,12 +44,10 @@ def test_label_usage():
     label_usage_zero_recycling = LabelUsage(
         base_model=base_model,
         num_classes=num_classes,
-        num_recycling_iterations=0,
     )
 
     output = label_usage_zero_recycling(feat=x, edge_index=edge_index, y=y,
-                                        mask=train_idx, val_idx=val_idx,
-                                        test_idx=test_idx)
+                                        mask=mask)
     assert output.size(0) == x.size(0)
     assert output.size(1) == num_classes
 
@@ -44,7 +56,6 @@ def test_label_usage():
     label_usage_2d = LabelUsage(base_model=base_model, num_classes=num_classes,
                                 split_ratio=0.6, num_recycling_iterations=10,
                                 return_tuple=False)
-    output = label_usage_2d(feat=x, edge_index=edge_index, y=y, mask=train_idx,
-                            val_idx=val_idx, test_idx=test_idx)
+    output = label_usage_2d(feat=x, edge_index=edge_index, y=y, mask=mask)
     assert output.size(0) == x.size(0)
     assert output.size(1) == num_classes

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -9,6 +9,8 @@ def test_label_usage():
     y = torch.tensor([1, 0, 0, 2, 1, 1])
     edge_index = torch.tensor([[0, 1, 1, 2, 4, 5], [1, 0, 2, 1, 5, 4]])
     train_idx = torch.tensor([0, 2, 3, 5])
+    val_idx = torch.tensor([1])
+    test_idx = torch.tensor([4])
 
     num_classes = len(torch.unique(y))
     base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8, num_layers=3, out_channels=num_classes)
@@ -17,25 +19,56 @@ def test_label_usage():
         num_classes=num_classes,
         split_ratio=0.6, 
         num_recycling_iterations=10, 
-        return_tuple=True, 
+        return_tuple=True
     )
     
-    output, train_labels_idx, train_pred_idx = label_usage(x, edge_index, y, train_idx)
+    output, train_labels_idx, train_pred_idx = label_usage(
+        feat=x, 
+        edge_index=edge_index, 
+        y=y, 
+        mask=train_idx, 
+        val_idx=val_idx, 
+        test_idx=test_idx
+    )
 
     # Check output shapes
     assert output.size(0) == x.size(0)
     assert output.size(1) == num_classes
 
-    # Check split ratio masking
-    actual_ratio = len(train_labels_idx) / len(train_idx)
-    assert torch.isclose(torch.tensor(actual_ratio), torch.tensor(label_usage.split_ratio), atol=0.1)
-
     # Test zero recycling iterations
-    label_usage = LabelUsage(
+    label_usage_zero_recycling = LabelUsage(
         base_model=base_model,
         num_classes=num_classes,
         num_recycling_iterations=0, 
     )
-    output = label_usage(x, edge_index, y, train_idx)
+
+    output = label_usage_zero_recycling(
+        feat=x, 
+        edge_index=edge_index, 
+        y=y, 
+        mask=train_idx, 
+        val_idx=val_idx, 
+        test_idx=test_idx
+    )
+    assert output.size(0) == x.size(0)
+    assert output.size(1) == num_classes
+
+    # Test 2D label tensor
+    y = torch.tensor([[1], [0], [0], [2], [1], [1]])  # Node labels (N, 1)
+    label_usage_2d = LabelUsage(
+        base_model=base_model,
+        num_classes=num_classes,
+        split_ratio=0.6, 
+        num_recycling_iterations=10, 
+        return_tuple=False
+    )
+    output = label_usage_2d(
+        feat=x, 
+        edge_index=edge_index, 
+        y=y, 
+        mask=train_idx, 
+        val_idx=val_idx, 
+        test_idx=test_idx
+    )
     assert output.size(0) == x.size(0)
     assert output.size(1) == num_classes

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -14,22 +14,13 @@ def test_label_usage():
     num_classes = len(torch.unique(y))
     base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8,
                      num_layers=3, out_channels=num_classes)
-    label_usage = LabelUsage(
-        base_model=base_model,
-        num_classes=num_classes,
-        split_ratio=0.6, 
-        num_recycling_iterations=10, 
-        return_tuple=True
-    )
-    
+    label_usage = LabelUsage(base_model=base_model, num_classes=num_classes,
+                             split_ratio=0.6, num_recycling_iterations=10,
+                             return_tuple=True)
+
     output, train_labels_idx, train_pred_idx = label_usage(
-        feat=x, 
-        edge_index=edge_index, 
-        y=y, 
-        mask=train_idx, 
-        val_idx=val_idx, 
-        test_idx=test_idx
-    )
+        feat=x, edge_index=edge_index, y=y, mask=train_idx, val_idx=val_idx,
+        test_idx=test_idx)
 
     # Check output shapes
     assert output.size(0) == x.size(0)
@@ -42,33 +33,18 @@ def test_label_usage():
         num_recycling_iterations=0,
     )
 
-    output = label_usage_zero_recycling(
-        feat=x, 
-        edge_index=edge_index, 
-        y=y, 
-        mask=train_idx, 
-        val_idx=val_idx, 
-        test_idx=test_idx
-    )
+    output = label_usage_zero_recycling(feat=x, edge_index=edge_index, y=y,
+                                        mask=train_idx, val_idx=val_idx,
+                                        test_idx=test_idx)
     assert output.size(0) == x.size(0)
     assert output.size(1) == num_classes
 
     # Test 2D label tensor
     y = torch.tensor([[1], [0], [0], [2], [1], [1]])  # Node labels (N, 1)
-    label_usage_2d = LabelUsage(
-        base_model=base_model,
-        num_classes=num_classes,
-        split_ratio=0.6, 
-        num_recycling_iterations=10, 
-        return_tuple=False
-    )
-    output = label_usage_2d(
-        feat=x, 
-        edge_index=edge_index, 
-        y=y, 
-        mask=train_idx, 
-        val_idx=val_idx, 
-        test_idx=test_idx
-    )
+    label_usage_2d = LabelUsage(base_model=base_model, num_classes=num_classes,
+                                split_ratio=0.6, num_recycling_iterations=10,
+                                return_tuple=False)
+    output = label_usage_2d(feat=x, edge_index=edge_index, y=y, mask=train_idx,
+                            val_idx=val_idx, test_idx=test_idx)
     assert output.size(0) == x.size(0)
     assert output.size(1) == num_classes

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -32,7 +32,7 @@ def test_label_usage():
     # Test zero recycling iterations
     label_usage = LabelUsage(
         split_ratio=0.5, 
-        num_recycling_iterations=10, 
+        num_recycling_iterations=0, 
         return_tuple=False, 
         base_model=base_model,
     )

--- a/test/nn/models/test_label_usage.py
+++ b/test/nn/models/test_label_usage.py
@@ -1,0 +1,41 @@
+import torch
+
+from torch_geometric.nn.models import LabelUsage
+from torch_geometric.nn.models import GCN
+
+
+def test_label_usage():
+    x = torch.rand(6, 4) # 6 nodes, 4 features
+    y = torch.tensor([1, 0, 0, 2, 1, 1])
+    edge_index = torch.tensor([[0, 1, 1, 2, 4, 5], [1, 0, 2, 1, 5, 4]])
+    train_idx = torch.tensor([0, 2, 3, 5])
+
+    num_classes = len(torch.unique(y))
+    base_model = GCN(in_channels=x.size(1) + num_classes, hidden_channels=8, num_layers=3, out_channels=num_classes)
+    label_usage = LabelUsage(
+        split_ratio=0.5, 
+        num_recycling_iterations=10, 
+        return_tuple=True, 
+        base_model=base_model,
+    )
+    
+    output, train_labels_idx, train_pred_idx = label_usage(x, edge_index, y, train_idx)
+
+    # Check output shapes
+    assert output.size(0) == x.size(0)
+    assert output.size(1) == num_classes
+
+    # Check split ratio masking
+    actual_ratio = len(train_labels_idx) / len(train_idx)
+    assert torch.isclose(torch.tensor(actual_ratio), torch.tensor(label_usage.split_ratio), atol=0.1)
+
+    # Test zero recycling iterations
+    label_usage = LabelUsage(
+        split_ratio=0.5, 
+        num_recycling_iterations=10, 
+        return_tuple=False, 
+        base_model=base_model,
+    )
+    output = label_usage(x, edge_index, y, train_idx)
+    assert output.size(0) == x.size(0)
+    assert output.size(1) == num_classes

--- a/torch_geometric/nn/models/__init__.py
+++ b/torch_geometric/nn/models/__init__.py
@@ -17,6 +17,7 @@ from .metapath2vec import MetaPath2Vec
 from .deepgcn import DeepGCNLayer
 from .tgn import TGNMemory
 from .label_prop import LabelPropagation
+from .label_usage import LabelUsage
 from .correct_and_smooth import CorrectAndSmooth
 from .attentive_fp import AttentiveFP
 from .rect import RECT_L
@@ -65,6 +66,7 @@ __all__ = classes = [
     'DeepGCNLayer',
     'TGNMemory',
     'LabelPropagation',
+    'LabelUsage',
     'CorrectAndSmooth',
     'AttentiveFP',
     'RECT_L',

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -15,11 +15,10 @@ class LabelUsage(torch.nn.Module):
     Args:
         split_ratio (float): Proportion of true labels to use as features 
             during training.
-        num_recycling_iterations (int):  Number of iterations the previously
+        num_recycling_iterations (int): Number of iterations the previously
             predicted softlabels are used as features.
-        return_tuple (bool):  Whether we would like to return the predicted 
-            labels from the two sets separately, with index 
-            corresponding to the split.
+        return_tuple (bool): Whether to return the label indices from the split
+            sets separately along with the output
         base_model: An instance of the model that will do the 
             inner forward pass.
         num_classes (int): Number of classes in dataset
@@ -59,7 +58,7 @@ class LabelUsage(torch.nn.Module):
         return torch.cat([features, onehot], dim=-1)
 
     def forward(self, x, edge_index, y, train_idx):
-        """
+        r"""
         Forward pass using label usage algorithm.
 
         Args:
@@ -87,5 +86,5 @@ class LabelUsage(torch.nn.Module):
 
         # return tuples if specified
         if self.return_tuple:
-            return output[train_labels_idx], output[train_pred_idx], train_pred_idx
+            return output, train_labels_idx, train_pred_idx
         return output

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -17,8 +17,8 @@ class LabelUsage(torch.nn.Module):
             during training.
         num_recycling_iterations (int): Number of iterations the previously
             predicted softlabels are used as features.
-        return_tuple (bool): Whether to return the label indices from the split
-            sets separately along with the output
+        return_tuple (bool): If true, returns (output, train_label_idx, 
+        train_pred_idx) otherwise returns prediction output
         base_model: An instance of the model that will do the 
             inner forward pass.
         num_classes (int): Number of classes in dataset
@@ -30,7 +30,6 @@ class LabelUsage(torch.nn.Module):
         num_recycling_iterations: int,
         return_tuple: bool,
         base_model: torch.nn.Module,
-        num_classes: int,
     ):
 
         super(LabelUsage, self).__init__()
@@ -38,7 +37,6 @@ class LabelUsage(torch.nn.Module):
         self.num_recycling_iterations = num_recycling_iterations
         self.return_tuple = return_tuple
         self.base_model = base_model
-        self.num_classes = num_classes
 
     def forward(self, x, edge_index, y, train_idx):
         r"""
@@ -57,7 +55,7 @@ class LabelUsage(torch.nn.Module):
         train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels in training
 
         # add labels to features for train_labels_idx nodes
-        onehot = torch.zeros([x.shape[0], self.num_classes]).to(x.device)
+        onehot = torch.zeros([x.shape[0], len(torch.unique(y))]).to(x.device)
         onehot[train_labels_idx, y[idx]] = 1  # create a one-hot encoding
         feat = torch.cat([x, onehot], dim=-1)
 

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -49,7 +49,7 @@ class LabelUsage(torch.nn.Module):
         edge_index: Adj, 
         y: Tensor, 
         train_idx: Tensor,
-        batch_mask: OptTensor = None,
+        batch: OptTensor = None,
         ):
         r"""
         Forward pass using label usage algorithm.
@@ -60,12 +60,12 @@ class LabelUsage(torch.nn.Module):
             y (torch.Tensor): Node label tensor 
             train_idx (torch.Tensor): Global indices of all 
                 nodes in training set
-            batch_mask (torch.Tensor, optional): Optional mask indicating 
-                global node indices in batch (default: :obj:'None')
+            batch (torch.Tensor, optional): Optional mini-batch specification
+                indicating global node indices in batch (default: :obj:'None')
         """
         # re-assign train_idx to be nodes in mini-batch
-        if batch_mask is not None:
-            train_idx = batch_mask
+        if batch is not None:
+            train_idx = batch
 
         # random masking to split train_idx based on split ratio
         mask = torch.rand(train_idx.shape) < self.split_ratio

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -1,8 +1,9 @@
 import torch
-from torch import Tensor
 import torch.nn.functional as F
+from torch import Tensor
 
-from torch_geometric.typing import Adj, SparseTensor
+from torch_geometric.typing import Adj
+
 
 class LabelUsage(torch.nn.Module):
     r"""The label usage operator for semi-supervised node classification,
@@ -21,10 +22,10 @@ class LabelUsage(torch.nn.Module):
         split_ratio (float): Proportion of true labels to use as features
             during training (default: :obj:'0.5')
         num_recycling_iterations (int): Number of iterations for the
-            label reuse procedure to cycle predicted soft labels 
+            label reuse procedure to cycle predicted soft labels
             (default: :obj:'0')
-        return_tuple (bool): If true, returns (output, train_label_idx, 
-            train_pred_idx) otherwise returns prediction output 
+        return_tuple (bool): If true, returns (output, train_label_idx,
+            train_pred_idx) otherwise returns prediction output
             (default :obj:'False')
     """
     def __init__(
@@ -45,31 +46,30 @@ class LabelUsage(torch.nn.Module):
 
     def forward(
         self,
-        feat: Tensor, 
-        edge_index: Adj, 
+        feat: Tensor,
+        edge_index: Adj,
         y: Tensor,
-        mask: Tensor, 
+        mask: Tensor,
         val_idx: Tensor,
         test_idx: Tensor,
-        ):
-        r"""
-        Forward pass using label usage algorithm.
+    ):
+        r"""Forward pass using label usage algorithm.
 
         Args:
             feat (torch.Tensor): Node feature tensor of dimension (N,F)
-                where N is the number of nodes and 
+                where N is the number of nodes and
                 F is the number of features per node
             edge_index (torch.Tensor or SparseTensor): The edge indices with
                 dimension (N,N) for a dense adjacency matrix or (2,E) for a
                 sparse adjacency representation where E is the number of edges
             y (torch.Tensor): Node ground-truth labels tensor of dimension
                 of (N,) for 1D tensor or (N,1) for 2D tensor
-            mask (torch.Tensor): Global indices of all nodes in training 
+            mask (torch.Tensor): Global indices of all nodes in training
                 set or mini-batch with dimension (N_train,) where N_train
                 is the number of nodes in training set or mini-batch
-            val_idx (torch.Tensor): Node indices in validation set with 
+            val_idx (torch.Tensor): Node indices in validation set with
                 dimension (N_val,) where N_val is the number of nodes
-                in validation set 
+                in validation set
             test_idx (torch.Tensor): Node indices in test set with dimension
                 (N_test,) where N_test is the number of nodes in test set
         """
@@ -77,26 +77,28 @@ class LabelUsage(torch.nn.Module):
 
         # random split mask based on split ratio
         split_mask = torch.rand(mask.shape) < self.split_ratio
-        train_labels_idx = mask[split_mask]  # D_L: nodes with features and labels
-        train_pred_idx = mask[~split_mask]  # D_U: nodes to predict labels 
+        train_labels_idx = mask[
+            split_mask]  # D_L: nodes with features and labels
+        train_pred_idx = mask[~split_mask]  # D_U: nodes to predict labels
 
         # add labels to features for train_labels_idx nodes
         # zero value nodes in train_pred_idx
         onehot = torch.zeros([feat.shape[0], self.num_classes]).to(feat.device)
         # create a one-hot encoding according to tensor dim
         if y.dim() == 2:
-            onehot[train_labels_idx, y[train_labels_idx,0]] = 1  
+            onehot[train_labels_idx, y[train_labels_idx, 0]] = 1
         else:
-            onehot[train_labels_idx, y[train_labels_idx]] = 1 
+            onehot[train_labels_idx, y[train_labels_idx]] = 1
         feat = torch.cat([feat, onehot], dim=-1)
 
         # set predictions for all unlabeled indices
         unlabeled_idx = torch.cat([train_pred_idx, val_idx, test_idx])
         # label reuse procedure
         pred = self.base_model(feat, edge_index)
-        for _ in range(max(1, self.num_recycling_iterations+1)):
+        for _ in range(max(1, self.num_recycling_iterations + 1)):
             pred = pred.detach()
-            feat[unlabeled_idx, -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
+            feat[unlabeled_idx,
+                 -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
             pred = self.base_model(feat, edge_index)
 
         # return tuples if specified

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -46,15 +46,16 @@ class LabelUsage(torch.nn.Module):
           x: Node feature tensor 
           edge_index: The edge connectivity
           y: Node label tensor 
-          train_idx: Training index tensor with labels
+          train_idx: Training index tensor 
 
         """
         # random masking to split train_idx based on split ratio
         mask = torch.rand(train_idx.shape) < self.split_ratio
         train_labels_idx = train_idx[mask]  # D_L: nodes with features and labels
-        train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels in training
+        train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels 
 
         # add labels to features for train_labels_idx nodes
+        # zero value nodes in train_pred_idx
         onehot = torch.zeros([x.shape[0], len(torch.unique(y))]).to(x.device)
         onehot[train_labels_idx, y[train_labels_idx]] = 1  # create a one-hot encoding
         feat = torch.cat([x, onehot], dim=-1)

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -1,7 +1,8 @@
 import torch
+from torch import Tensor
 import torch.nn.functional as F
 
-from torch_geometric.typing import OptTensor, Adj
+from torch_geometric.typing import Adj, SparseTensor
 
 class LabelUsage(torch.nn.Module):
     r"""The label usage operator for semi-supervised node classification,
@@ -21,7 +22,7 @@ class LabelUsage(torch.nn.Module):
             during training (default: :obj:'0.5')
         num_recycling_iterations (int): Number of iterations for the
             label reuse procedure to cycle predicted soft labels 
-            (default: :obj:'100')
+            (default: :obj:'0')
         return_tuple (bool): If true, returns (output, train_label_idx, 
             train_pred_idx) otherwise returns prediction output 
             (default :obj:'False')
@@ -32,7 +33,7 @@ class LabelUsage(torch.nn.Module):
         base_model: torch.nn.Module,
         num_classes: int,
         split_ratio: float = 0.5,
-        num_recycling_iterations: int = 100,
+        num_recycling_iterations: int = 0,
         return_tuple: bool = False,
     ):
 
@@ -45,46 +46,59 @@ class LabelUsage(torch.nn.Module):
 
     def forward(
         self,
-        x: Tensor, 
+        feat: Tensor, 
         edge_index: Adj, 
-        y: Tensor, 
-        train_idx: Tensor,
-        batch: OptTensor = None,
+        y: Tensor,
+        mask: Tensor, 
+        val_idx: Tensor,
+        test_idx: Tensor,
         ):
         r"""
         Forward pass using label usage algorithm.
 
         Args:
-            x (torch.Tensor): Node feature tensor 
-            edge_index (torch.Tensor or SparseTensor): The edge indices
-            y (torch.Tensor): Node label tensor 
-            train_idx (torch.Tensor): Global indices of all 
-                nodes in training set
-            batch (torch.Tensor, optional): Optional mini-batch specification
-                indicating global node indices in batch (default: :obj:'None')
+            feat (torch.Tensor): Node feature tensor of dimension (N,F)
+                where N is the number of nodes and 
+                F is the number of features per node
+            edge_index (torch.Tensor or SparseTensor): The edge indices with
+                dimension (N,N) for a dense adjacency matrix or (2,E) for a
+                sparse adjacency representation where E is the number of edges
+            y (torch.Tensor): Node ground-truth labels tensor of dimension
+                of (N,) for 1D tensor or (N,1) for 2D tensor
+            mask (torch.Tensor): Global indices of all nodes in training 
+                set or mini-batch with dimension (N_train,) where N_train
+                is the number of nodes in training set or mini-batch
+            val_idx (torch.Tensor): Node indices in validation set with 
+                dimension (N_val,) where N_val is the number of nodes
+                in validation set 
+            test_idx (torch.Tensor): Node indices in test set with dimension
+                (N_test,) where N_test is the number of nodes in test set
         """
-        # re-assign train_idx to be nodes in mini-batch
-        if batch is not None:
-            train_idx = batch
+        assert feat.dim() == 2, "feat must be 2D but got shape {feat.shape}"
 
-        # random masking to split train_idx based on split ratio
-        mask = torch.rand(train_idx.shape) < self.split_ratio
-        train_labels_idx = train_idx[mask]  # D_L: nodes with features and labels
-        train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels 
+        # random split mask based on split ratio
+        split_mask = torch.rand(mask.shape) < self.split_ratio
+        train_labels_idx = mask[split_mask]  # D_L: nodes with features and labels
+        train_pred_idx = mask[~split_mask]  # D_U: nodes to predict labels 
 
         # add labels to features for train_labels_idx nodes
         # zero value nodes in train_pred_idx
-        onehot = torch.zeros([x.shape[0], self.num_classes]).to(x.device)
-        onehot[train_labels_idx, y[train_labels_idx]] = 1  # create a one-hot encoding
-        feat = torch.cat([x, onehot], dim=-1)
+        onehot = torch.zeros([feat.shape[0], self.num_classes]).to(feat.device)
+        # create a one-hot encoding according to tensor dim
+        if y.dim() == 2:
+            onehot[train_labels_idx, y[train_labels_idx,0]] = 1  
+        else:
+            onehot[train_labels_idx, y[train_labels_idx]] = 1 
+        feat = torch.cat([feat, onehot], dim=-1)
 
+        # set predictions for all unlabeled indices
+        unlabeled_idx = torch.cat([train_pred_idx, val_idx, test_idx])
         # label reuse procedure
-        for _ in range(max(1, self.num_recycling_iterations)):
-            output = self.base_model(feat, edge_index)
-            pred_labels = F.softmax(output, dim=1)
-            feat[train_pred_idx] = torch.cat(
-                [x[train_pred_idx], pred_labels[train_pred_idx]], dim=1
-            )
+        pred = self.base_model(feat, edge_index)
+        for _ in range(max(1, self.num_recycling_iterations+1)):
+            pred = pred.detach()
+            feat[unlabeled_idx, -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
+            pred = self.base_model(feat, edge_index)
 
         # return tuples if specified
         if self.return_tuple:

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -14,7 +14,7 @@ class LabelUsage(torch.nn.Module):
     labeled subset incorporates labels as features while the unlabeled subset
     labels are zeroed and used for prediction. During inference, previously
     predicted soft labels for unlabeled nodes are recycled as inputs for the
-    model, refining predictions iteratively. 
+    model, refining predictions iteratively.
 
     .. note::
 
@@ -31,7 +31,7 @@ class LabelUsage(torch.nn.Module):
             label reuse procedure to cycle predicted soft labels
             (default: :obj:'0')
         return_tuple (bool): If true, returns (pred, train_label,
-            train_pred) during training otherwise returns 
+            train_pred) during training otherwise returns
             prediction output (default :obj:'False')
     """
     def __init__(
@@ -61,7 +61,7 @@ class LabelUsage(torch.nn.Module):
 
         Args:
             feat (torch.Tensor): Node feature tensor of dimension (N,F)
-                where N is the number of nodes and F is the number 
+                where N is the number of nodes and F is the number
                 of features per node
             edge_index (torch.Tensor or SparseTensor): The edge connectivity
                 to be passed to base_model
@@ -75,8 +75,8 @@ class LabelUsage(torch.nn.Module):
             f"Expected y to be either (N,) or (N, 1), but got shape {y.shape}"
 
         # set unlabeled mask for unlabeled indices
-        unlabeled_mask = torch.ones(feat.size(0), 
-            dtype=torch.bool).to(feat.device)
+        unlabeled_mask = torch.ones(feat.size(0),
+                                    dtype=torch.bool).to(feat.device)
 
         # add labels to features for train_labels nodes if in training
         # else fill true labels for all nodes in mask
@@ -87,8 +87,8 @@ class LabelUsage(torch.nn.Module):
             if mask.dtype == torch.bool:
                 mask = mask.nonzero(as_tuple=False).view(-1)
             split_mask = torch.rand(mask.shape) < self.split_ratio
-            train_labels = mask[split_mask] # D_L: nodes with labels
-            train_pred = mask[~split_mask] # D_U: nodes to predict labels
+            train_labels = mask[split_mask]  # D_L: nodes with labels
+            train_pred = mask[~split_mask]  # D_U: nodes to predict labels
 
             unlabeled_mask[train_labels] = False
 
@@ -105,7 +105,7 @@ class LabelUsage(torch.nn.Module):
                 onehot[mask, y[mask, 0]] = 1
             else:
                 onehot[mask, y[mask]] = 1
-                
+
         feat = torch.cat([feat, onehot], dim=-1)
 
         pred = self.base_model(feat, edge_index)
@@ -114,7 +114,7 @@ class LabelUsage(torch.nn.Module):
         for _ in range(self.num_recycling_iterations):
             pred = pred.detach()
             feat[unlabeled_mask,
-                -self.num_classes:] = F.softmax(pred[unlabeled_mask], dim=-1)
+                 -self.num_classes:] = F.softmax(pred[unlabeled_mask], dim=-1)
             pred = self.base_model(feat, edge_index)
 
         # return tuples if specified

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -33,9 +33,6 @@ class LabelUsage(torch.nn.Module):
         return_tuple (bool): If true, returns (pred, train_label,
             train_pred) during training otherwise returns 
             prediction output (default :obj:'False')
-        training (bool): If true, sets forward method to training mode and
-            utilizes split ratio else runs evaluation and uses all training
-            node labels as features (default :obj:'True')
     """
     def __init__(
         self,
@@ -44,7 +41,6 @@ class LabelUsage(torch.nn.Module):
         split_ratio: float = 0.5,
         num_recycling_iterations: int = 0,
         return_tuple: bool = False,
-        training: bool = True
     ):
 
         super().__init__()
@@ -53,7 +49,6 @@ class LabelUsage(torch.nn.Module):
         self.split_ratio = split_ratio
         self.num_recycling_iterations = num_recycling_iterations
         self.return_tuple = return_tuple
-        self.training = training
 
     def forward(
         self,

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -40,19 +40,7 @@ class LabelUsage(torch.nn.Module):
         self.base_model = base_model
         self.num_classes = num_classes
 
-        # TODO: Account for expanding input dimension
-        # self.original_in_channels = self.base_model.in_channels
-        # self.expanded_in_channels = self.original_in_channels + self.num_classes
-
     def add_labels(self, features, labels, idx):
-        """
-        Augment training nodes to include labels with features for specified training index
-
-        Args:
-          features: feature tensor (x)
-          labels: label tensor (y)
-          idx: Training index tensor with labels
-        """
         onehot = torch.zeros([features.shape[0], self.num_classes]).to(features.device)
         onehot[idx, labels[idx]] = 1  # create a one-hot encoding
         return torch.cat([features, onehot], dim=-1)
@@ -62,9 +50,9 @@ class LabelUsage(torch.nn.Module):
         Forward pass using label usage algorithm.
 
         Args:
-          x: Node feature tensor (x)
+          x: Node feature tensor 
           edge_index: The edge connectivity
-          y: Node label tensor (y)
+          y: Node label tensor 
           train_idx: Training index tensor with labels
 
         """
@@ -74,6 +62,7 @@ class LabelUsage(torch.nn.Module):
         train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels in training
 
         # add labels to features for train_labels_idx nodes
+        #
         feat = self.add_labels(x, y, train_labels_idx)
 
         # label reuse procedure

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -71,7 +71,7 @@ class LabelUsage(torch.nn.Module):
                 are used during training
         """
         assert feat.dim() == 2, f"feat must be 2D but got shape {feat.shape}"
-        assert y.dim() == 1 or (y.dim() == 2 and y.size(1) == 1),\
+        assert y.dim() == 1 or (y.dim() == 2 and y.size(1) == 1), \
             f"Expected y to be either (N,) or (N, 1), but got shape {y.shape}"
 
         # set unlabeled mask for unlabeled indices

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -33,6 +33,9 @@ class LabelUsage(torch.nn.Module):
         return_tuple (bool): If true, returns (pred, train_label,
             train_pred) during training otherwise returns 
             prediction output (default :obj:'False')
+        training (bool): If true, sets forward method to training mode and
+            utilizes split ratio else runs evaluation and uses all training
+            node labels as features (default :obj:'True')
     """
     def __init__(
         self,

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -1,7 +1,8 @@
 import torch
 import torch.nn.functional as F
 
-from torch_geometric.typing import OptTensor, Adj
+from torch_geometric.typing import Adj, OptTensor
+
 
 class LabelUsage(torch.nn.Module):
     r"""The label usage operator for semi-supervised node classification,
@@ -14,19 +15,18 @@ class LabelUsage(torch.nn.Module):
         accordingly to include both features and classes.
 
     Args:
-        base_model: An instance of the model that will do the 
+        base_model: An instance of the model that will do the
             inner forward pass.
         num_classes (int): Number of classes in dataset
-        split_ratio (float): Proportion of true labels to use as features 
+        split_ratio (float): Proportion of true labels to use as features
             during training (default: :obj:'0.5')
         num_recycling_iterations (int): Number of iterations for the
-            label reuse procedure to cycle predicted soft labels 
+            label reuse procedure to cycle predicted soft labels
             (default: :obj:'100')
-        return_tuple (bool): If true, returns (output, train_label_idx, 
-            train_pred_idx) otherwise returns prediction output 
+        return_tuple (bool): If true, returns (output, train_label_idx,
+            train_pred_idx) otherwise returns prediction output
             (default :obj:'False')
     """
-
     def __init__(
         self,
         base_model: torch.nn.Module,
@@ -36,7 +36,7 @@ class LabelUsage(torch.nn.Module):
         return_tuple: bool = False,
     ):
 
-        super(LabelUsage, self).__init__()
+        super().__init__()
         self.base_model = base_model
         self.num_classes = num_classes
         self.split_ratio = split_ratio
@@ -45,20 +45,19 @@ class LabelUsage(torch.nn.Module):
 
     def forward(
         self,
-        x: Tensor, 
-        edge_index: Adj, 
-        y: Tensor, 
+        x: Tensor,
+        edge_index: Adj,
+        y: Tensor,
         train_idx: Tensor,
         batch: OptTensor = None,
-        ):
-        r"""
-        Forward pass using label usage algorithm.
+    ):
+        r"""Forward pass using label usage algorithm.
 
         Args:
-            x (torch.Tensor): Node feature tensor 
+            x (torch.Tensor): Node feature tensor
             edge_index (torch.Tensor or SparseTensor): The edge indices
-            y (torch.Tensor): Node label tensor 
-            train_idx (torch.Tensor): Global indices of all 
+            y (torch.Tensor): Node label tensor
+            train_idx (torch.Tensor): Global indices of all
                 nodes in training set
             batch (torch.Tensor, optional): Optional mini-batch specification
                 indicating global node indices in batch (default: :obj:'None')
@@ -69,13 +68,15 @@ class LabelUsage(torch.nn.Module):
 
         # random masking to split train_idx based on split ratio
         mask = torch.rand(train_idx.shape) < self.split_ratio
-        train_labels_idx = train_idx[mask]  # D_L: nodes with features and labels
-        train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels 
+        train_labels_idx = train_idx[
+            mask]  # D_L: nodes with features and labels
+        train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels
 
         # add labels to features for train_labels_idx nodes
         # zero value nodes in train_pred_idx
         onehot = torch.zeros([x.shape[0], self.num_classes]).to(x.device)
-        onehot[train_labels_idx, y[train_labels_idx]] = 1  # create a one-hot encoding
+        onehot[train_labels_idx,
+               y[train_labels_idx]] = 1  # create a one-hot encoding
         feat = torch.cat([x, onehot], dim=-1)
 
         # label reuse procedure
@@ -83,8 +84,7 @@ class LabelUsage(torch.nn.Module):
             output = self.base_model(feat, edge_index)
             pred_labels = F.softmax(output, dim=1)
             feat[train_pred_idx] = torch.cat(
-                [x[train_pred_idx], pred_labels[train_pred_idx]], dim=1
-            )
+                [x[train_pred_idx], pred_labels[train_pred_idx]], dim=1)
 
         # return tuples if specified
         if self.return_tuple:

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -13,12 +13,15 @@ class LabelUsage(torch.nn.Module):
         accordingly to include both features and classes.
 
     Args:
-        split_ratio (float): Proportion of true labels to use as features during training.
-        num_recycling_iterations (int):  Number of iterations the previously predicted soft
-            labels are used as features.
-        return_tuple (bool):  Whether we would like to return the predicted labels from the two
-            sets separately, with index corresponding to the split.
-        base_model: An instance of the model that will do the inner forward pass.
+        split_ratio (float): Proportion of true labels to use as features 
+            during training.
+        num_recycling_iterations (int):  Number of iterations the previously
+            predicted softlabels are used as features.
+        return_tuple (bool):  Whether we would like to return the predicted 
+            labels from the two sets separately, with index 
+            corresponding to the split.
+        base_model: An instance of the model that will do the 
+            inner forward pass.
         num_classes (int): Number of classes in dataset
     """
 

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -101,5 +101,5 @@ class LabelUsage(torch.nn.Module):
 
         # return tuples if specified
         if self.return_tuple:
-            return output, train_labels_idx, train_pred_idx
-        return output
+            return pred, train_labels_idx, train_pred_idx
+        return pred

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -63,9 +63,9 @@ class LabelUsage(torch.nn.Module):
             batch_mask (torch.Tensor, optional): Optional mask indicating 
                 global node indices in batch (default: :obj:'None')
         """
-        # filter out nodes not in the mini-batch
+        # re-assign train_idx to be nodes in mini-batch
         if batch_mask is not None:
-            train_idx = train_idx[torch.isin(train_idx, batch_mask)]
+            train_idx = batch_mask
 
         # random masking to split train_idx based on split ratio
         mask = torch.rand(train_idx.shape) < self.split_ratio

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -77,8 +77,8 @@ class LabelUsage(torch.nn.Module):
 
         # random split mask based on split ratio
         split_mask = torch.rand(mask.shape) < self.split_ratio
-        train_labels_idx = mask[split_mask] # D_L: nodes with labels
-        train_pred_idx = mask[~split_mask] # D_U: nodes to predict labels
+        train_labels_idx = mask[split_mask]  # D_L: nodes with labels
+        train_pred_idx = mask[~split_mask]  # D_U: nodes to predict labels
 
         assert y.dim() == 1 or (y.dim() == 2 and y.size(1) == 1),\
             "Expected y to be either (N,) or (N, 1), but got shape {y.shape}"
@@ -99,7 +99,7 @@ class LabelUsage(torch.nn.Module):
         for _ in range(max(1, self.num_recycling_iterations + 1)):
             pred = pred.detach()
             feat[unlabeled_idx,
-                -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
+                 -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
             pred = self.base_model(feat, edge_index)
 
         # return tuples if specified

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -1,0 +1,88 @@
+import torch
+import torch.nn.functional as F
+
+
+class LabelUsage(torch.nn.Module):
+    r"""The label usage operator for semi-supervised node classification,
+    as introduced in `"Bag of Tricks for Node Classification"
+    <https://arxiv.org/abs/2103.13355>`_ paper.
+
+    .. note::
+
+        When using the :class:`LabelUsage`, adjust the model's input dimension
+        accordingly to include both features and classes.
+
+    Args:
+        split_ratio (float): Proportion of true labels to use as features during training.
+        num_recycling_iterations (int):  Number of iterations the previously predicted soft
+            labels are used as features.
+        return_tuple (bool):  Whether we would like to return the predicted labels from the two
+            sets separately, with index corresponding to the split.
+        base_model: An instance of the model that will do the inner forward pass.
+        num_classes (int): Number of classes in dataset
+    """
+
+    def __init__(
+        self,
+        split_ratio: float,
+        num_recycling_iterations: int,
+        return_tuple: bool,
+        base_model: torch.nn.Module,
+        num_classes: int,
+    ):
+
+        super(LabelUsage, self).__init__()
+        self.split_ratio = split_ratio
+        self.num_recycling_iterations = num_recycling_iterations
+        self.return_tuple = return_tuple
+        self.base_model = base_model
+        self.num_classes = num_classes
+
+        # TODO: Account for expanding input dimension
+        # self.original_in_channels = self.base_model.in_channels
+        # self.expanded_in_channels = self.original_in_channels + self.num_classes
+
+    def add_labels(self, features, labels, idx):
+        """
+        Augment training nodes to include labels with features for specified training index
+
+        Args:
+          features: feature tensor (x)
+          labels: label tensor (y)
+          idx: Training index tensor with labels
+        """
+        onehot = torch.zeros([features.shape[0], self.num_classes]).to(features.device)
+        onehot[idx, labels[idx]] = 1  # create a one-hot encoding
+        return torch.cat([features, onehot], dim=-1)
+
+    def forward(self, x, edge_index, y, train_idx):
+        """
+        Forward pass using label usage algorithm.
+
+        Args:
+          x: Node feature tensor (x)
+          edge_index: The edge connectivity
+          y: Node label tensor (y)
+          train_idx: Training index tensor with labels
+
+        """
+        # random masking to split train_idx based on split ratio
+        mask = torch.rand(train_idx.shape) < self.split_ratio
+        train_labels_idx = train_idx[mask]  # D_L: nodes with features and labels
+        train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels in training
+
+        # add labels to features for train_labels_idx nodes
+        feat = self.add_labels(x, y, train_labels_idx)
+
+        # label reuse procedure
+        for _ in range(self.num_recycling_iterations):
+            output = self.base_model(feat, edge_index)
+            pred_labels = F.softmax(output, dim=1)
+            feat[train_pred_idx] = torch.cat(
+                [x[train_pred_idx], pred_labels[train_pred_idx]], dim=1
+            )
+
+        # return tuples if specified
+        if self.return_tuple:
+            return output[train_labels_idx], output[train_pred_idx], train_pred_idx
+        return output

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -15,8 +15,8 @@ class LabelUsage(torch.nn.Module):
     Args:
         split_ratio (float): Proportion of true labels to use as features 
             during training.
-        num_recycling_iterations (int): Number of iterations the previously
-            predicted softlabels are used as features.
+        num_recycling_iterations (int): Number of iterations for the label
+            reuse procedure to cycle predicted soft labels
         return_tuple (bool): If true, returns (output, train_label_idx, 
         train_pred_idx) otherwise returns prediction output
         base_model: An instance of the model that will do the 
@@ -56,11 +56,11 @@ class LabelUsage(torch.nn.Module):
 
         # add labels to features for train_labels_idx nodes
         onehot = torch.zeros([x.shape[0], len(torch.unique(y))]).to(x.device)
-        onehot[train_labels_idx, y[idx]] = 1  # create a one-hot encoding
+        onehot[train_labels_idx, y[train_labels_idx]] = 1  # create a one-hot encoding
         feat = torch.cat([x, onehot], dim=-1)
 
         # label reuse procedure
-        for _ in range(self.num_recycling_iterations):
+        for _ in range(max(1, self.num_recycling_iterations)):
             output = self.base_model(feat, edge_index)
             pred_labels = F.softmax(output, dim=1)
             feat[train_pred_idx] = torch.cat(

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -40,11 +40,6 @@ class LabelUsage(torch.nn.Module):
         self.base_model = base_model
         self.num_classes = num_classes
 
-    def add_labels(self, features, labels, idx):
-        onehot = torch.zeros([features.shape[0], self.num_classes]).to(features.device)
-        onehot[idx, labels[idx]] = 1  # create a one-hot encoding
-        return torch.cat([features, onehot], dim=-1)
-
     def forward(self, x, edge_index, y, train_idx):
         r"""
         Forward pass using label usage algorithm.
@@ -62,8 +57,9 @@ class LabelUsage(torch.nn.Module):
         train_pred_idx = train_idx[~mask]  # D_U: nodes to predict labels in training
 
         # add labels to features for train_labels_idx nodes
-        #
-        feat = self.add_labels(x, y, train_labels_idx)
+        onehot = torch.zeros([x.shape[0], self.num_classes]).to(x.device)
+        onehot[train_labels_idx, y[idx]] = 1  # create a one-hot encoding
+        feat = torch.cat([x, onehot], dim=-1)
 
         # label reuse procedure
         for _ in range(self.num_recycling_iterations):

--- a/torch_geometric/nn/models/label_usage.py
+++ b/torch_geometric/nn/models/label_usage.py
@@ -77,10 +77,11 @@ class LabelUsage(torch.nn.Module):
 
         # random split mask based on split ratio
         split_mask = torch.rand(mask.shape) < self.split_ratio
-        train_labels_idx = mask[
-            split_mask]  # D_L: nodes with features and labels
-        train_pred_idx = mask[~split_mask]  # D_U: nodes to predict labels
+        train_labels_idx = mask[split_mask] # D_L: nodes with labels
+        train_pred_idx = mask[~split_mask] # D_U: nodes to predict labels
 
+        assert y.dim() == 1 or (y.dim() == 2 and y.size(1) == 1),\
+            "Expected y to be either (N,) or (N, 1), but got shape {y.shape}"
         # add labels to features for train_labels_idx nodes
         # zero value nodes in train_pred_idx
         onehot = torch.zeros([feat.shape[0], self.num_classes]).to(feat.device)
@@ -98,7 +99,7 @@ class LabelUsage(torch.nn.Module):
         for _ in range(max(1, self.num_recycling_iterations + 1)):
             pred = pred.detach()
             feat[unlabeled_idx,
-                 -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
+                -self.num_classes:] = F.softmax(pred[unlabeled_idx], dim=-1)
             pred = self.base_model(feat, edge_index)
 
         # return tuples if specified


### PR DESCRIPTION
Add `label_usage.py` to torch_geometric.nn.models and unit test.

Part of [#4](https://github.com/mattjhayes3/pytorch_geometric/issues/4) (TODO update this) for our final project for the Stanford CS224W course, this implements Label Usage as described in [“Bag of Tricks for Node Classification with Graph Neural Networks”](https://arxiv.org/abs/2103.13355).

### Description of Label Usage

- Label usage utilizes true labels as features and learns to predict other labels. 
- Within label usage, label reuse is done to recycle predicted soft labels of previous iterations and uses the labels as input
- When in training, label usage performs a split on the training nodes and predicts all other unlabeled nodes
- In evaluation, label usage doesn't perform split but uses true labels for training nodes and predicts on validation and test nodes
- The base model should have input dimensions of `num_features + num_classes` to accommodate concatenation of labels with features

### Benchmark
Run on Arxiv (ogbn-arvix) dataset with 100 epochs, 10 recycling iterations, and a split ratio of 0.6 using a GAT model.
| Dataset | Val Accuracy (%) | Test Accuracy (%) |
| ------------- | ------------- | ------------- |
| Arxiv  | 69.32  | 68.53  |