### PR TITLE
CS224W - Bag of Tricks for Node Classification with GNN - Non interactive GAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `interactive_attn` parameter to `GATConv` and `GATv2Conv` ([#9832](https://github.com/pyg-team/pytorch_geometric/pull/9832))
 - Update Dockerfile to use latest from NVIDIA ([#9794](https://github.com/pyg-team/pytorch_geometric/pull/9794))
 - Added various GRetriever Architecture Benchmarking examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))
 - Added `profiler.nvtxit` with some examples ([#9666](https://github.com/pyg-team/pytorch_geometric/pull/9666))

--- a/benchmark/citation/gat.py
+++ b/benchmark/citation/gat.py
@@ -24,15 +24,21 @@ parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
 parser.add_argument('--compile', action='store_true')
+parser.add_argument('--non_interactive', action='store_true')
 args = parser.parse_args()
 
 
 class Net(torch.nn.Module):
     def __init__(self, dataset):
         super().__init__()
-        self.conv1 = GATConv(dataset.num_features, args.hidden,
-                             heads=args.heads, dropout=args.dropout)
-        self.conv2 = GATConv(args.hidden * args.heads, dataset.num_classes,
+        in_channels_1 = dataset.num_features
+        in_channels_2 = args.hidden * args.heads
+        if args.non_interactive:
+            in_channels_1 = (in_channels_1, None)
+            in_channels_2 = (in_channels_2, None)
+        self.conv1 = GATConv(in_channels_1, args.hidden, heads=args.heads,
+                             dropout=args.dropout)
+        self.conv2 = GATConv(in_channels_2, dataset.num_classes,
                              heads=args.output_heads, concat=False,
                              dropout=args.dropout)
 

--- a/benchmark/citation/gat.py
+++ b/benchmark/citation/gat.py
@@ -24,21 +24,15 @@ parser.add_argument('--inference', action='store_true')
 parser.add_argument('--profile', action='store_true')
 parser.add_argument('--bf16', action='store_true')
 parser.add_argument('--compile', action='store_true')
-parser.add_argument('--non_interactive', action='store_true')
 args = parser.parse_args()
 
 
 class Net(torch.nn.Module):
     def __init__(self, dataset):
         super().__init__()
-        in_channels_1 = dataset.num_features
-        in_channels_2 = args.hidden * args.heads
-        if args.non_interactive:
-            in_channels_1 = (in_channels_1, None)
-            in_channels_2 = (in_channels_2, None)
-        self.conv1 = GATConv(in_channels_1, args.hidden, heads=args.heads,
-                             dropout=args.dropout)
-        self.conv2 = GATConv(in_channels_2, dataset.num_classes,
+        self.conv1 = GATConv(dataset.num_features, args.hidden,
+                             heads=args.heads, dropout=args.dropout)
+        self.conv2 = GATConv(args.hidden * args.heads, dataset.num_classes,
                              heads=args.output_heads, concat=False,
                              dropout=args.dropout)
 

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -12,13 +12,15 @@ from torch_geometric.utils import to_torch_csc_tensor
 
 
 @pytest.mark.parametrize('residual', [False, True])
-def test_gat_conv(residual):
+@pytest.mark.parametrize('interactive_attn', [False, True])
+def test_gat_conv(residual, interactive_attn):
     x1 = torch.randn(4, 8)
     x2 = torch.randn(2, 16)
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
 
-    conv = GATConv(8, 32, heads=2, residual=residual)
+    conv = GATConv(8, 32, heads=2, residual=residual,
+                   interactive_attn=interactive_attn)
     assert str(conv) == 'GATConv(8, 32, heads=2)'
     out = conv(x1, edge_index)
     assert out.size() == (4, 64)
@@ -111,44 +113,11 @@ def test_gat_conv(residual):
             assert torch.allclose(result[0], out, atol=1e-6)
             assert result[1].sizes() == [4, 4, 2] and result[1].nnz() == 7
 
-    # Test no target features in attention
-    conv = GATConv((8, None), 32, heads=2, residual=residual)
-    assert str(conv) == 'GATConv((8, None), 32, heads=2)'
-    out = conv(x1, edge_index)
-    assert out.size() == (4, 64)
-    assert torch.allclose(conv(x1, edge_index, size=(4, 4)), out)
-    assert torch.allclose(conv(x1, adj1.t()), out, atol=1e-6)
-
-    if torch_geometric.typing.WITH_TORCH_SPARSE:
-        adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
-        assert torch.allclose(conv(x1, adj2.t()), out, atol=1e-6)
-
-    if is_full_test():
-
-        class MyModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv = conv
-
-            def forward(
-                self,
-                x: Tensor,
-                edge_index: Adj,
-                size: Size = None,
-            ) -> Tensor:
-                return self.conv(x, edge_index, size=size)
-
-        jit = torch.jit.script(MyModule())
-        assert torch.allclose(jit(x1, edge_index), out)
-        assert torch.allclose(jit(x1, edge_index, size=(4, 4)), out)
-
-        if torch_geometric.typing.WITH_TORCH_SPARSE:
-            assert torch.allclose(jit(x1, adj2.t()), out, atol=1e-6)
-
     # Test bipartite message passing:
     adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
 
-    conv = GATConv((8, 16), 32, heads=2, residual=residual)
+    conv = GATConv((8, 16), 32, heads=2, residual=residual,
+                   interactive_attn=interactive_attn)
     assert str(conv) == 'GATConv((8, 16), 32, heads=2)'
 
     out1 = conv((x1, x2), edge_index)

--- a/test/nn/conv/test_gat_conv.py
+++ b/test/nn/conv/test_gat_conv.py
@@ -111,6 +111,40 @@ def test_gat_conv(residual):
             assert torch.allclose(result[0], out, atol=1e-6)
             assert result[1].sizes() == [4, 4, 2] and result[1].nnz() == 7
 
+    # Test no target features in attention
+    conv = GATConv((8, None), 32, heads=2, residual=residual)
+    assert str(conv) == 'GATConv((8, None), 32, heads=2)'
+    out = conv(x1, edge_index)
+    assert out.size() == (4, 64)
+    assert torch.allclose(conv(x1, edge_index, size=(4, 4)), out)
+    assert torch.allclose(conv(x1, adj1.t()), out, atol=1e-6)
+
+    if torch_geometric.typing.WITH_TORCH_SPARSE:
+        adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
+        assert torch.allclose(conv(x1, adj2.t()), out, atol=1e-6)
+
+    if is_full_test():
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = conv
+
+            def forward(
+                self,
+                x: Tensor,
+                edge_index: Adj,
+                size: Size = None,
+            ) -> Tensor:
+                return self.conv(x, edge_index, size=size)
+
+        jit = torch.jit.script(MyModule())
+        assert torch.allclose(jit(x1, edge_index), out)
+        assert torch.allclose(jit(x1, edge_index, size=(4, 4)), out)
+
+        if torch_geometric.typing.WITH_TORCH_SPARSE:
+            assert torch.allclose(jit(x1, adj2.t()), out, atol=1e-6)
+
     # Test bipartite message passing:
     adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
 

--- a/test/nn/conv/test_gatv2_conv.py
+++ b/test/nn/conv/test_gatv2_conv.py
@@ -12,13 +12,15 @@ from torch_geometric.utils import to_torch_csc_tensor
 
 
 @pytest.mark.parametrize('residual', [False, True])
-def test_gatv2_conv(residual):
+@pytest.mark.parametrize('interactive_attn', [False, True])
+def test_gatv2_conv(residual, interactive_attn):
     x1 = torch.randn(4, 8)
     x2 = torch.randn(2, 8)
     edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
     adj1 = to_torch_csc_tensor(edge_index, size=(4, 4))
 
-    conv = GATv2Conv(8, 32, heads=2, residual=residual)
+    conv = GATv2Conv(8, 32, heads=2, residual=residual,
+                     interactive_attn=interactive_attn)
     assert str(conv) == 'GATv2Conv(8, 32, heads=2)'
     out = conv(x1, edge_index)
     assert out.size() == (4, 64)
@@ -109,42 +111,8 @@ def test_gatv2_conv(residual):
             assert torch.allclose(result[0], out, atol=1e-6)
             assert result[1].sizes() == [4, 4, 2] and result[1].nnz() == 7
 
-    # Test no target features in attention
-    conv = GATv2Conv((8, None), 32, heads=2, residual=residual)
-    assert str(conv) == 'GATv2Conv((8, None), 32, heads=2)'
-    out = conv(x1, edge_index)
-    assert out.size() == (4, 64)
-    assert torch.allclose(conv(x1, edge_index), out)
-    assert torch.allclose(conv(x1, adj1.t()), out, atol=1e-6)
-
-    if torch_geometric.typing.WITH_TORCH_SPARSE:
-        adj2 = SparseTensor.from_edge_index(edge_index, sparse_sizes=(4, 4))
-        assert torch.allclose(conv(x1, adj2.t()), out, atol=1e-6)
-
-    if is_full_test():
-
-        class MyModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv = conv
-
-            def forward(
-                self,
-                x: Tensor,
-                edge_index: Adj,
-            ) -> Tensor:
-                return self.conv(x, edge_index)
-
-        jit = torch.jit.script(MyModule())
-        assert torch.allclose(jit(x1, edge_index), out)
-
-        if torch_geometric.typing.WITH_TORCH_SPARSE:
-            assert torch.allclose(jit(x1, adj2.t()), out, atol=1e-6)
-
     # Test bipartite message passing:
     adj1 = to_torch_csc_tensor(edge_index, size=(4, 2))
-
-    conv = GATv2Conv(8, 32, heads=2, residual=residual)
 
     out = conv((x1, x2), edge_index)
     assert out.size() == (2, 64)

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -73,14 +73,17 @@ class GATConv(MessagePassing):
         + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{i,k}
         \right)\right)}.
 
-    If the graph is not bipartite, :math:`\mathbf{\Theta}_{s} =
+    If an integer is passed for :obj:`in_channels`, :math:`\mathbf{\Theta}_{s} =
     \mathbf{\Theta}_{t}`.
 
     Args:
         in_channels (int or tuple): Size of each input sample, or :obj:`-1` to
             derive the size from the first input(s) to the forward method.
-            A tuple corresponds to the sizes of source and target
-            dimensionalities in case of a bipartite graph.
+            A tuple dictates the dimensionality of distinct 
+            :math:`\mathbf{\Theta}` to be used for source and target features,
+            for example, in case of a bipartite graph.  A value of :obj:`None|0`
+            for the source dimensionality fixes 
+            :math:`\mathbf{\Theta}_s=\mathbf{0}`.
         out_channels (int): Size of each output sample.
         heads (int, optional): Number of multi-head-attentions.
             (default: :obj:`1`)
@@ -156,10 +159,10 @@ class GATConv(MessagePassing):
         self.fill_value = fill_value
         self.residual = residual
 
-        # In case we are operating in bipartite graphs, we apply separate
-        # transformations 'lin_src' and 'lin_dst' to source and target nodes:
+        # In case of e.g. bipartite graphs, we apply separate transformations 
+        # 'lin_src' and 'lin_dst' to source and target nodes:
         self.lin = self.lin_src = self.lin_dst = None
-        if isinstance(in_channels, int):
+        if isinstance(in_channels, int) or not in_channels[0]:
             self.lin = Linear(in_channels, heads * out_channels, bias=False,
                               weight_initializer='glorot')
         else:
@@ -169,8 +172,10 @@ class GATConv(MessagePassing):
                                   weight_initializer='glorot')
 
         # The learnable parameters to compute attention coefficients:
-        self.att_src = Parameter(torch.empty(1, heads, out_channels))
         self.att_dst = Parameter(torch.empty(1, heads, out_channels))
+        self.att_src = None
+        if isinstance(in_channels, int) or in_channels[0]:
+            self.att_src = Parameter(torch.empty(1, heads, out_channels))
 
         if edge_dim is not None:
             self.lin_edge = Linear(edge_dim, heads * out_channels, bias=False,
@@ -285,7 +290,6 @@ class GATConv(MessagePassing):
         # `torch.jit._overload` decorator, as we can only change the output
         # arguments conditioned on type (`None` or `bool`), not based on its
         # actual value.
-
         H, C = self.heads, self.out_channels
 
         res: Optional[Tensor] = None
@@ -301,8 +305,9 @@ class GATConv(MessagePassing):
             if self.lin is not None:
                 x_src = x_dst = self.lin(x).view(-1, H, C)
             else:
-                # If the module is initialized as bipartite, transform source
-                # and destination node features separately:
+                # If the module is initialized with a tuple of positive 
+                # in_channels, transform source and destination node features
+                # separately:
                 assert self.lin_src is not None and self.lin_dst is not None
                 x_src = self.lin_src(x).view(-1, H, C)
                 x_dst = self.lin_dst(x).view(-1, H, C)
@@ -315,9 +320,9 @@ class GATConv(MessagePassing):
                 res = self.res(x_dst)
 
             if self.lin is not None:
-                # If the module is initialized as non-bipartite, we expect that
-                # source and destination node features have the same shape and
-                # that they their transformations are shared:
+                # If the module is initialized with integer in_channels, we
+                # expect that source and destination node features have the same
+                # shape and that they their transformations are shared:
                 x_src = self.lin(x_src).view(-1, H, C)
                 if x_dst is not None:
                     x_dst = self.lin(x_dst).view(-1, H, C)

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -46,13 +46,13 @@ class GATConv(MessagePassing):
         \alpha_{i,j} =
         \frac{
         \exp\left(\mathrm{LeakyReLU}\left(
-        \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_i
-        + \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_j
+        \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i
+        + \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_j
         \right)\right)}
         {\sum_{k \in \mathcal{N}(i) \cup \{ i \}}
         \exp\left(\mathrm{LeakyReLU}\left(
-        \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_i
-        + \mathbf{a}^{\top}_{t}\mathbf{\Theta}_{t}\mathbf{x}_k
+        \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i
+        + \mathbf{a}^{\top}_{s}\mathbf{\Theta}_{s}\mathbf{x}_k
         \right)\right)}.
 
     If the graph has multi-dimensional edge features :math:`\mathbf{e}_{i,j}`,
@@ -62,14 +62,14 @@ class GATConv(MessagePassing):
         \alpha_{i,j} =
         \frac{
         \exp\left(\mathrm{LeakyReLU}\left(
-        \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_i
-        + \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_j
+        \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i
+        + \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_j
         + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{i,j}
         \right)\right)}
         {\sum_{k \in \mathcal{N}(i) \cup \{ i \}}
         \exp\left(\mathrm{LeakyReLU}\left(
-        \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_i
-        + \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_k
+        \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i
+        + \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_k
         + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{i,k}
         \right)\right)}.
 

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -55,7 +55,7 @@ class GATConv(MessagePassing):
         + \mathbf{a}^{\top}_{s}\mathbf{\Theta}_{s}\mathbf{x}_k
         \right)\right)}.
 
-    If the graph has multi-dimensional edge features :math:`\mathbf{e}_{i,j}`,
+    If the graph has multi-dimensional edge features :math:`\mathbf{e}_{j,i}`,
     the attention coefficients :math:`\alpha_{i,j}` are computed as
 
     .. math::
@@ -64,13 +64,13 @@ class GATConv(MessagePassing):
         \exp\left(\mathrm{LeakyReLU}\left(
         \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i
         + \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_j
-        + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{i,j}
+        + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{j,i}
         \right)\right)}
         {\sum_{k \in \mathcal{N}(i) \cup \{ i \}}
         \exp\left(\mathrm{LeakyReLU}\left(
         \mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i
         + \mathbf{a}^{\top}_{s} \mathbf{\Theta}_{s}\mathbf{x}_k
-        + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{i,k}
+        + \mathbf{a}^{\top}_{e} \mathbf{\Theta}_{e} \mathbf{e}_{k,i}
         \right)\right)}.
 
     If an integer is passed for :obj:`in_channels`, :math:`\mathbf{\Theta}_{s}
@@ -110,6 +110,9 @@ class GATConv(MessagePassing):
             an additive bias. (default: :obj:`True`)
         residual (bool, optional): If set to :obj:`True`, the layer will add
             a learnable skip-connection. (default: :obj:`False`)
+        interactive_attn (bool, optional): If set to :obj:`False`, fixes
+            :math:`\mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i = 0`.
+            (default :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
 

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -334,7 +334,6 @@ class GATConv(MessagePassing):
                 # same shape and that they their transformations are shared:
                 x_src = self.lin(x_src).view(-1, H, C)
                 if x_dst is not None and self.interactive_attn:
-                    assert self.lin_dst is not None
                     x_dst = self.lin(x_dst).view(-1, H, C)
             else:
                 assert self.lin_src is not None

--- a/torch_geometric/nn/conv/gat_conv.py
+++ b/torch_geometric/nn/conv/gat_conv.py
@@ -159,7 +159,7 @@ class GATConv(MessagePassing):
         self.residual = residual
         self.interactive_attn = interactive_attn
 
-        # In case tuple in_channels, we apply separate transformations
+        # In case of tuple in_channels, we apply separate transformations
         # 'lin_src' and 'lin_dst' to source and target nodes:
         self.lin = self.lin_src = self.lin_dst = None
         if isinstance(in_channels, int):

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -114,8 +114,7 @@ class GATv2Conv(MessagePassing):
         residual (bool, optional): If set to :obj:`True`, the layer will add
             a learnable skip-connection. (default: :obj:`False`)
         interactive_attn (bool, optional): If set to :obj:`False`, fixes
-            :math:`\mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i = 0`.
-            (default :obj:`True`)
+            :math:`\mathbf{\Theta}_{t}\mathbf{x}_i = 0`. (default :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
 

--- a/torch_geometric/nn/conv/gatv2_conv.py
+++ b/torch_geometric/nn/conv/gatv2_conv.py
@@ -57,7 +57,7 @@ class GATv2Conv(MessagePassing):
         \mathbf{\Theta}_{t} \mathbf{x}_i + \mathbf{\Theta}_{s} \mathbf{x}_k
         \right)\right)}.
 
-    If the graph has multi-dimensional edge features :math:`\mathbf{e}_{i,j}`,
+    If the graph has multi-dimensional edge features :math:`\mathbf{e}_{j,i}`,
     the attention coefficients :math:`\alpha_{i,j}` are computed as
 
     .. math::
@@ -66,13 +66,13 @@ class GATv2Conv(MessagePassing):
         \exp\left(\mathbf{a}^{\top}\mathrm{LeakyReLU}\left(
         \mathbf{\Theta}_{t} \mathbf{x}_i
         + \mathbf{\Theta}_{s} \mathbf{x}_j
-        + \mathbf{\Theta}_{e} \mathbf{e}_{i,j}
+        + \mathbf{\Theta}_{e} \mathbf{e}_{j,i}
         \right)\right)}
         {\sum_{k \in \mathcal{N}(i) \cup \{ i \}}
         \exp\left(\mathbf{a}^{\top}\mathrm{LeakyReLU}\left(
         \mathbf{\Theta}_{t} \mathbf{x}_i
         + \mathbf{\Theta}_{s} \mathbf{x}_k
-        + \mathbf{\Theta}_{e} \mathbf{e}_{i,k}]
+        + \mathbf{\Theta}_{e} \mathbf{e}_{k,i}]
         \right)\right)}.
 
     Args:
@@ -113,6 +113,9 @@ class GATv2Conv(MessagePassing):
             (default: :obj:`False`)
         residual (bool, optional): If set to :obj:`True`, the layer will add
             a learnable skip-connection. (default: :obj:`False`)
+        interactive_attn (bool, optional): If set to :obj:`False`, fixes
+            :math:`\mathbf{a}^{\top}_{t} \mathbf{\Theta}_{t}\mathbf{x}_i = 0`.
+            (default :obj:`True`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
 


### PR DESCRIPTION
Add `interactive_attn` parameter to `GATConv` and `GATv2Conv`.  

Part of #4 (TODO update this), this allows “Non-interactive” attention as described in [“Bag of Tricks for Node Classification with Graph Neural Networks”](https://arxiv.org/abs/2103.13355).  

* There is already a subtle way to achieve non-interactive attention by passing `(x, None)` to forward, however this method
	* Doesn’t work with residuals in the bipartite case
	* Adds complexity in hyperparameter search in comparison to passing in `kwargs`
	* Can’t be used except in first layer with existing models.GAT
	* Is not documented and not very readable
* We currently include some documentation and comment changes that are only tangentially related.  Happy to revert them to focus the change, but we believe it makes the workings of the module a little clearer.
	* Tuple `in_channels` can be used with non-bipartite graphs.  E.g. `(d, d)` can be passed in `GATConv` to learn separate source and target weights for the same features, or users might want a separate set of features when a node is a source vs target.  
	* Swap `s` and `t` in the notation as `i` and `j` are typically the target and source nodes respectively.  This is also more consistent with `GATConv`’s `lin_src` and `lin_dst`.
* We could slightly reduce changes in `GATConv.forward` by reusing the tuple `in_channels` path when `iteractive_attn=False` and `in_channels` is an integer, but this could be confusing

The paper does not provide any metrics or performance references. `benchmarks/citation` reveals non-interactive is faster by ~2-16% on Colab's T4s with typically no effect on performance.  It may be slightly worse on Cora v1+no_random_splits and v2+random_splits but slightly better on PubMed v1+random_splits.  

Deltas below are expressed in the direction `interactive - non_interactive`.  For Arxiv we used the default hyperparameters from `benchmarks/citation/gat.py` with a batch norm inserted, and for v2 the same as v1, though these are surely suboptimal settings.  
| interactive_command                                                                          | val_acc_abs_delta   | val_acc_pval   | test_acc_abs_delta   | test_acc_pval   | duration_rel_delta   | duration_pval   |
|:---------------------------------------------------------------------------------------------|:--------------------|:---------------|:---------------------|:----------------|:---------------------|:----------------|
| **gat.py --dataset=Cora**                                                                        | 0.14%               | 12.31%         | **0.11%**                | **6.54%**           | 3.80%                | 0.08%           |
| gat.py --dataset=Cora --v2                                                                   | 0.05%               | 58.70%         | 0.01%                | 82.66%          | 7.55%                | 0.00%           |
| gat.py --dataset=Cora --random_splits                                                        | 0.01%               | 96.71%         | -0.16%               | 45.78%          | 2.77%                | 0.75%           |
| **gat.py --dataset=Cora --random_splits --v2**                                                   | -0.09%              | 76.30%         | **0.44%**                | **4.97%**           | 6.15%                | 0.00%           |
| gat.py --dataset=CiteSeer                                                                    | -0.25%              | 2.00%          | 0.08%                | 26.67%          | 2.04%                | 1.96%           |
| gat.py --dataset=CiteSeer --v2                                                               | 0.12%               | 27.36%         | -0.01%               | 86.19%          | 13.58%               | 0.00%           |
| gat.py --dataset=CiteSeer --random_splits                                                    | 0.18%               | 56.38%         | -0.15%               | 58.17%          | 4.67%                | 0.00%           |
| gat.py --dataset=CiteSeer --random_splits --v2                                               | 0.18%               | 57.16%         | -0.13%               | 61.36%          | 13.28%               | 0.00%           |
| gat.py --dataset=PubMed --lr=0.01 --output_heads=8 --weight_decay=0.001                      | -0.04%              | 64.61%         | 0.00%                | 92.15%          | 7.02%                | 0.00%           |
| gat.py --dataset=PubMed --lr=0.01 --output_heads=8 --v2 --weight_decay=0.001                 | 0.03%               | 70.07%         | 0.00%                | 94.62%          | 15.79%               | 0.00%           |
| **gat.py --dataset=PubMed --lr=0.01 --output_heads=8 --random_splits --weight_decay=0.001**      | -0.31%              | 45.31%         | **-0.59%**               | **9.35%**           | 7.63%                | 0.00%           |
| gat.py --dataset=PubMed --lr=0.01 --output_heads=8 --random_splits --v2 --weight_decay=0.001 | 0.14%               | 71.39%         | 0.16%                | 64.16%          | 15.54%               | 0.00%           |
| gat.py --batch_norm --dataset=Arxiv --no_normalize_features --runs=20                        | -0.00%              | 94.04%         | -0.08%               | 43.23%          | 5.65%                | 0.00%           |
| gat.py --batch_norm --dataset=Arxiv --no_normalize_features --runs=20 --v2                   | 0.02%               | 72.76%         | -0.10%               | 33.38%          | 12.63%               | 0.00%           |

Full metrics: [[interactive](https://github.com/mattjhayes3/pytorch_geometric/blob/non_interactive_testing/gat_baseline.tsv)] [[non-interactive](https://github.com/mattjhayes3/pytorch_geometric/blob/non_interactive_testing/gat_non_interactive.tsv)]